### PR TITLE
Handlebars helper pass through

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,27 @@ minimize.parse(
 );
 ```
 
+
+**Handlebars**
+
+Minimize will not parse the assignments inside template directives as html
+attributes when it detects they are part of an Handlebars helper
+Downside: all characters in the Handlebars helper will be transformed to
+lowercase
+
+```javascript
+var Minimize = require('minimize'),
+    minimize = new Minimize({ handlebars: true });
+
+var html = '<option value="aValue" \
+                    {{#ifCond someCond isTrue}}selected="selected"{{/ifCond}} \
+                    class="a-class an-other-class"></div>';
+
+minimize.parse(html, function (error, data) {
+  // data output: <option value=aValue {{#ifcond somecond istrue}}selected=selected {{/ifcond}} class="a-class an-other-class"></option>
+});
+```
+
 **Plugins**
 
 Register a set of plugins that will be ran on each iterated element. Plugins

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,7 +17,8 @@ var config = {
   spare: false,        // remove(false) or retain(true) redundant attributes
   quotes: false,       // remove(false) or retain(true) quotes if not required
   loose: false,        // remove(false) all or retain(true) one whitespace
-  whitespace: false    // remove(false) or retain(true) whitespace in attributes
+  whitespace: false,   // remove(false) or retain(true) whitespace in attributes
+  handlebars: false    // ignore(false) or treat(true) handlebars attribute template
 };
 
 /**
@@ -116,10 +117,12 @@ Helpers.prototype.attributes = function attributes(element) {
   var attr = element.attribs
     , self = this
     , name = element.name
-    , value, bool, allowed;
+    , value, bool, allowed, inHandlebarsTemplate;
 
   if (!attr || typeof attr !== 'object') return '';
   return Object.keys(attr).reduce(function (result, key) {
+    var handlebarsDelimiter;
+
     value = attr[key];
     bool = ~list.redundant.indexOf(key);
 
@@ -131,6 +134,29 @@ Helpers.prototype.attributes = function attributes(element) {
     allowed = allowed
       ? allowed === '*' || ~allowed.indexOf(name)
       : ~key.indexOf('data-');
+
+    //
+    // Keep returning the full attribute and value when we are in an
+    // handlebars template
+    //
+    if (self.config.handlebars && !allowed) {
+      // Start of an handlebars template
+      if (!inHandlebarsTemplate && key.indexOf('{{') === 0) {
+        inHandlebarsTemplate = true;
+        return result + ' ' + key;
+      // End of an handlebars template
+      } else if (key.indexOf('}}') === key.length - 2) {
+        inHandlebarsTemplate = false;
+        handlebarsDelimiter = key.indexOf('/') === 0 ? '' : '/';
+        return result + handlebarsDelimiter + key;
+      // While in an handlebars template
+      } else if (inHandlebarsTemplate) {
+        if (value) {
+          return result + ' ' + key + '=' + self.quote(!self.config.whitespace ? compact(value).trim() : value);
+        }
+        return result + ' ' + key;
+      }
+    }
 
     //
     // Remove attributes that are empty, not boolean and no semantic value.

--- a/test/fixtures/html.json
+++ b/test/fixtures/html.json
@@ -25,6 +25,7 @@
   "complexconditional": "<head><!--[if lt IE 9]>      <html class=\"no-js lt-ie9\"> <![endif]--><!--[if gt IE 8]><!--> <link rel=\"some.file.com\"> <!--<![endif]--></head>",
   "conditionalcomments": "<head><!--[if IE 6]>Special instructions for IE 6 here<![endif]--></head><h1><!-- Some comments thats either removed or kept --></h1>",
   "whitespace": "<input value=\" with newlines \n and whitespace\">",
+  "handlebars": "<option value=\"aValue\" {{#ifCond someCond isTrue}}selected=\"selected\"{{/ifCond}} class=\"a-class an-other-class\"></div>",
   "doctype": {
     "data": "!doctype html",
     "type": "directive",

--- a/test/minimize-test.js
+++ b/test/minimize-test.js
@@ -165,6 +165,14 @@ describe('Minimize', function () {
       });
     });
 
+    it('should be configurable to retain Handlebars template declared as element attributes', function (done) {
+      var handlebars = new Minimize({ handlebars: true });
+      handlebars.parse(html.handlebars, function (error, result) {
+        expect(result).to.equal('<option value=aValue {{#ifcond somecond istrue}}selected=selected {{/ifcond}} class="a-class an-other-class"></option>');
+        done();
+      });
+    });
+
     it('should leave structural elements (like scripts and code) intact', function (done) {
       minimize.parse(html.code, function (error, result) {
         expect(result).to.equal("<code class=copy>\n<span>var http = require('http');\nhttp.createServer(function (req, res) {\n    res.writeHead(200, {'Content-Type': 'text/plain'});\n    res.end('hello, i know nodejitsu');\n})listen(8080);</span><a href=#><s class=ss-layers role=presentation></s> copy</a></code>");


### PR DESCRIPTION
Related to #52, this PR adds a pass through, through the `handlebars` option, to not parse Handlebars helpers as attribute when they reside outside of an element attribute. When parsing an element attributes, it looks for the Handlebars template delimiter (`{{`) and if it finds it at the beginning of the attribute name, it returns unparsed attributes + key until it finds the closing delimiter (`}}`). If an "attributes" has a value, it parses it correctly.

What do you think ? Is this something that's too "hacky" ? I've tested with a bunch of different options enabled and with different attributes, before, after, in between and it seems to be pretty solid.  My main concern is that I'm not familiar with the way htmlparser2 splits elements attributes into it's tree, so I may well be forgetting test cases.
