### PR TITLE
Addressing issue 63, allowed.indexOf is not a function

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -127,7 +127,7 @@ Helpers.prototype.attributes = function attributes(element) {
     // Is the attribute allowed on the HTML element? If so, allow special
     // treatment. If not, then just return the full attribute and its value.
     //
-    allowed = list.attributes[key];
+    allowed = String(list.attributes[key]);
     allowed = allowed
       ? allowed === '*' || ~allowed.indexOf(name)
       : ~key.indexOf('data-');


### PR DESCRIPTION
See issue #63 "TypeError: allowed.indexOf is not a function" when using IO.js v3.3.1.