### PR TITLE
Add the ability to keep case of attributesnames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.idea/
 lib-cov
 *.seed
 *.log

--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ object can be provided. All options are listed below and `false` per default.
 ```javascript
 var Minimize = require('minimize')
   , minimize = new Minimize({
-      empty: true,        // KEEP empty attributes
-      cdata: true,        // KEEP CDATA from scripts
-      comments: true,     // KEEP comments
-      ssi: true,          // KEEP Server Side Includes
-      conditionals: true, // KEEP conditional internet explorer comments
-      spare: true,        // KEEP redundant attributes
-      quotes: true,       // KEEP arbitrary quotes
-      loose: true         // KEEP one whitespace
+      empty: true,                      // KEEP empty attributes
+      cdata: true,                      // KEEP CDATA from scripts
+      comments: true,                   // KEEP comments
+      ssi: true,                        // KEEP Server Side Includes
+      conditionals: true,               // KEEP conditional internet explorer comments
+      spare: true,                      // KEEP redundant attributes
+      quotes: true,                     // KEEP arbitrary quotes
+      loose: true,                      // KEEP one whitespace
+      lowerCaseAttributeNames: false    // KEEP sensitive case attributes names
     });
 
 minimize.parse(content, function (error, data) {
@@ -213,6 +214,22 @@ minimize.parse(
   '<h1>title</h1>  <p class="paragraph" id="title">\n  content\n  </p>    ',
   function (error, data) {
     // data output: <h1>title</h1> <p class="paragraph" id="title"> content </p> '
+  }
+);
+```
+
+**lowerCaseAttributeNames**
+
+Minimize will lowercase all attributes names. If you need to conserve case set `false` to this option like below.
+
+```javascript
+var Minimize = require('minimize')
+  , minimize = new Minimize({ lowerCaseAttributeNames: false });
+
+minimize.parse(
+  '<a *ngIf="bool">link</a>',
+  function (error, data) {
+    // data output: <a *ngIf=bool>link</a> '
   }
 );
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ var Minimize = require('minimize')
       spare: true,                      // KEEP redundant attributes
       quotes: true,                     // KEEP arbitrary quotes
       loose: true,                      // KEEP one whitespace
-      lowerCaseAttributeNames: false    // KEEP sensitive case attributes names
+      dom: {                            // options of !(htmlparser2)[https://github.com/fb55/htmlparser2]
+            xmlMode: false,                     // Disables the special behavior for script/style tags (false by default)
+            lowerCaseAttributeNames: true,      // call .toLowerCase for each attribute name (true if xmlMode is `false`)
+            lowerCaseTags: true                 // call .toLowerCase for each tag name (true if xmlMode is `false`)
+      }
     });
 
 minimize.parse(content, function (error, data) {
@@ -218,13 +222,13 @@ minimize.parse(
 );
 ```
 
-**lowerCaseAttributeNames**
+**dom**
 
-Minimize will lowercase all attributes names. If you need to conserve case set `false` to this option like below.
+Minimize use !(htmlparser2)[https://github.com/fb55/htmlparser2] to parse the dom. The `dom` option permit to customize htmlparser2.
 
 ```javascript
 var Minimize = require('minimize')
-  , minimize = new Minimize({ lowerCaseAttributeNames: false });
+  , minimize = new Minimize({ dom: { lowerCaseAttributeNames: false }});
 
 minimize.parse(
   '<a *ngIf="bool">link</a>',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,15 +9,16 @@ var list = require('./list');
 // Predefined parsing options.
 //
 var config = {
-  empty: false,        // remove(false) or retain(true) empty attributes
-  cdata: false,        // remove(false) or retain(true) CDATA from scripts
-  comments: false,     // remove(false) or retain(true) comments
-  conditionals: false, // remove(false) or retain(true) ie conditional comments
-  ssi: false,          // remove(false) or retain(true) server side includes
-  spare: false,        // remove(false) or retain(true) redundant attributes
-  quotes: false,       // remove(false) or retain(true) quotes if not required
-  loose: false,        // remove(false) all or retain(true) one whitespace
-  whitespace: false    // remove(false) or retain(true) whitespace in attributes
+  empty: false,                     // remove(false) or retain(true) empty attributes
+  cdata: false,                     // remove(false) or retain(true) CDATA from scripts
+  comments: false,                  // remove(false) or retain(true) comments
+  conditionals: false,              // remove(false) or retain(true) ie conditional comments
+  ssi: false,                       // remove(false) or retain(true) server side includes
+  spare: false,                     // remove(false) or retain(true) redundant attributes
+  quotes: false,                    // remove(false) or retain(true) quotes if not required
+  loose: false,                     // remove(false) all or retain(true) one whitespace
+  whitespace: false,                // remove(false) or retain(true) whitespace in attributes
+  lowerCaseAttributeNames: true     // lowercase(true) or conserve(false) sensitive case for attributes names
 };
 
 /**
@@ -278,6 +279,10 @@ Helpers.prototype.comment = function comment(element) {
  */
 Helpers.prototype.directive = function directive(element) {
   return '<' + element.data + '>';
+};
+
+Helpers.prototype.htmlParserOptions = function htmlParserOptions() {
+  return {lowerCaseAttributeNames: this.config.lowerCaseAttributeNames === false ? false : config.lowerCaseAttributeNames};
 };
 
 //

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -18,7 +18,11 @@ var config = {
   quotes: false,                    // remove(false) or retain(true) quotes if not required
   loose: false,                     // remove(false) all or retain(true) one whitespace
   whitespace: false,                // remove(false) or retain(true) whitespace in attributes
-  lowerCaseAttributeNames: true     // lowercase(true) or conserve(false) sensitive case for attributes names
+  dom: {                            // see https://github.com/fb55/htmlparser2 for all options
+    xmlMode: false,                     // Disables the special behavior for script/style tags (false by default)
+    lowerCaseAttributeNames: true,      // call .toLowerCase for each attribute name (true if xmlMode is `false`)
+    lowerCaseTags: true                 // call .toLowerCase for each tag name (true if xmlMode is `false`)
+  }
 };
 
 /**
@@ -279,10 +283,6 @@ Helpers.prototype.comment = function comment(element) {
  */
 Helpers.prototype.directive = function directive(element) {
   return '<' + element.data + '>';
-};
-
-Helpers.prototype.htmlParserOptions = function htmlParserOptions() {
-  return {lowerCaseAttributeNames: this.config.lowerCaseAttributeNames === false ? false : config.lowerCaseAttributeNames};
 };
 
 //

--- a/lib/minimize.js
+++ b/lib/minimize.js
@@ -34,7 +34,7 @@ function Minimize(parser, options) {
   // Prepare the parser.
   //
   this.htmlparser = parser || new html.Parser(
-    new html.DomHandler(this.emits('read'))
+    new html.DomHandler(this.emits('read')), this.helpers.htmlParserOptions()
   );
 
   //

--- a/lib/minimize.js
+++ b/lib/minimize.js
@@ -23,6 +23,7 @@ var debug = require('diagnostics')('minimize')
 function Minimize(parser, options) {
   if ('object' !== typeof options) {
     options = parser || {};
+    options.dom = options.dom || {};
     parser = void 0;
   }
 
@@ -34,7 +35,7 @@ function Minimize(parser, options) {
   // Prepare the parser.
   //
   this.htmlparser = parser || new html.Parser(
-    new html.DomHandler(this.emits('read')), this.helpers.htmlParserOptions()
+    new html.DomHandler(this.emits('read')), options.dom
   );
 
   //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimize",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Minimize HTML",
   "main": "./lib/minimize",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimize",
-  "version": "1.7.5",
+  "version": "1.8.0",
   "description": "Minimize HTML",
   "main": "./lib/minimize",
   "bin": {

--- a/test/minimize-test.js
+++ b/test/minimize-test.js
@@ -368,6 +368,21 @@ describe('Minimize', function () {
       });
     });
 
+    it('should lower case attributes names', function (done) {
+      minimize.parse('<a ngIf="bool">test</a>', function (error, result) {
+        expect(result).to.equal('<a ngif=bool>test</a>');
+        done();
+      });
+    });
+
+    it('should conserve sensitive case of attributes', function (done) {
+      var lowerCase = new Minimize({ lowerCaseAttributeNames: false });
+      lowerCase.parse('<a ngIf="bool">test</a>', function (error, result) {
+        expect(result).to.equal('<a ngIf=bool>test</a>');
+        done();
+      });
+    });
+
     it('has the ability to use plugins to alter elements', function (done) {
       var pluggable = new Minimize({ plugins: [{
         id: 'test',

--- a/test/minimize-test.js
+++ b/test/minimize-test.js
@@ -376,7 +376,7 @@ describe('Minimize', function () {
     });
 
     it('should conserve sensitive case of attributes', function (done) {
-      var lowerCase = new Minimize({ lowerCaseAttributeNames: false });
+      var lowerCase = new Minimize({ dom: {lowerCaseAttributeNames: false} });
       lowerCase.parse('<a ngIf="bool">test</a>', function (error, result) {
         expect(result).to.equal('<a ngIf=bool>test</a>');
         done();


### PR DESCRIPTION
Hi,

Thanks for your job on this project!

I use it to inline my html templates in an angular2 project. To do this I need to keep attributes names with camel case (because of ngIf, ngFor... and [propertyName]...).

After some research I have found the option `lowerCaseAttributeNames` in htmlparser2, so I have added an option.

If you want I change something just tell me :smiley:

@+++ 