### PR TITLE
Drop old nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
+  - "4"
+  - "5"
+  - "6"
+  - "7"
+  - "8"
+  - "node"
 script:
   - "npm run test-travis"
 after_script:
-  - "npm install coveralls@2.11.x && cat coverage/lcov.info | coveralls"
+  - "npm install coveralls@3.0.x && cat coverage/lcov.info | coveralls"
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: "iojs"


### PR DESCRIPTION
I dropped old nodejs versions and updates coverall version

It fixes the build:
https://travis-ci.org/tomap/minimize
and the coverage works:
https://coveralls.io/github/tomap/minimize
You could add a badge once you merge the PR :)
